### PR TITLE
Fix serializing TargetSite property on Exceptions

### DIFF
--- a/Serilog.Sinks.Scalyr/MethodBaseConverter.cs
+++ b/Serilog.Sinks.Scalyr/MethodBaseConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Serilog.Sinks.Scalyr
+{
+  /// <inheritdoc />
+  /// <summary>
+  ///   Handles properly converting MethodBase objects to Json
+  /// </summary>
+  internal class MethodBaseConverter : JsonConverter<MethodBase>
+  {
+    /// <inheritdoc />
+    public override MethodBase Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+      throw new NotSupportedException("Deserializing RuntimeMethodHandles is not allowed");
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, MethodBase value, JsonSerializerOptions options)
+    {
+      writer.WriteStartObject();
+
+      WriteProperty("Name", value.Name);
+      WriteProperty("DeclaringType", value.DeclaringType?.FullName);
+      WriteProperty("Description", value.ToString());
+
+      writer.WriteEndObject();
+
+      void WriteProperty(string name, string propertyValue)
+      {
+        switch (options)
+        {
+          case { DefaultIgnoreCondition: JsonIgnoreCondition.WhenWritingNull }
+            or { IgnoreNullValues: true }
+            when propertyValue is null:
+          case { DefaultIgnoreCondition: JsonIgnoreCondition.WhenWritingDefault }
+            when propertyValue == default:
+            return;
+        }
+
+        writer.WritePropertyName(name);
+        writer.WriteStringValue(propertyValue);
+      }
+    }
+  }
+}

--- a/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
+++ b/Serilog.Sinks.Scalyr/SystemTextJsonScalyrFormatter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -10,6 +11,7 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Formatting.Json;
 
+[assembly: InternalsVisibleTo("Serilog.Sinks.Scalyr.Tests")]
 namespace Serilog.Sinks.Scalyr
 {
   internal class SystemTextJsonScalyrFormatter : IScalyrFormatter
@@ -26,7 +28,8 @@ namespace Serilog.Sinks.Scalyr
       _jsonSerializerSettings = new JsonSerializerOptions
       {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new MethodBaseConverter() }
       };
       _messageTemplateTextFormatter = messageTemplateTextFormatter;
       _session = new ScalyrSession { Token = token, Session = Guid.NewGuid().ToString("N") };


### PR DESCRIPTION
This PR adds the `MethodBaseConverter` which allows the `TargetSite` property of `Exceptions` to get serialized. 

The resulting json of a non-null `TargetSite` value will be:
``` json
"TargetSite": {
  "Name": "ThrowEx",
  "DeclaringType": "UserQuery",
  "Description": "Void ThrowEx()"
}
```

Fixes https://github.com/TinyBlueRobots/Serilog.Sinks.Scalyr/issues/2